### PR TITLE
chore(ci): migrate CI runners to Blacksmith

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -30,7 +30,7 @@ on:
 jobs:
   GoLangCI-Lint:
     name: Run GoLangCI-Lint
-    runs-on: ubuntu-24.04
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -51,7 +51,7 @@ jobs:
 
   GoSec:
     name: Run GoSec Security Scanner
-    runs-on: ubuntu-24.04
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -114,7 +114,7 @@ jobs:
 
   unit-tests:
     name: Run Unit Tests
-    runs-on: ubuntu-24.04
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v4
 
@@ -141,7 +141,7 @@ jobs:
 
   integration-tests:
     name: Run Integration Tests
-    runs-on: ubuntu-24.04
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   build_and_publish:
-    runs-on: ubuntu-24.04
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       # Login to Docker registry
       - name: Login to Docker Registry

--- a/.github/workflows/check-branch.yml
+++ b/.github/workflows/check-branch.yml
@@ -21,7 +21,7 @@ on:
 
 jobs:
   check-branch:
-    runs-on: ubuntu-24.04
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       # Generate GitHub App token for authentication
       - uses: actions/create-github-app-token@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ permissions:
 
 jobs:
   publish_release:
-    runs-on: ubuntu-24.04
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     environment:
       name: create_release
     name: Create Release


### PR DESCRIPTION
Migrates this repository's GitHub Actions jobs from GitHub-hosted runners to Blacksmith runners, as part of the org-wide migration. Every hardcoded `ubuntu-*` label (both `runs-on:` and `runner_type:` inputs passed to shared workflows) now points to Blacksmith:

```yaml
runs-on: blacksmith-4vcpu-ubuntu-2404
```

Jobs pinned to `ubuntu-22.04` map to `blacksmith-4vcpu-ubuntu-2204` to keep the same OS version. Self-hosted labels (`eveo-*`, `self-hosted`) are untouched, and no other workflow logic changed.
